### PR TITLE
Update go.mod to use the module's new name.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/alexjg/go-dag-jose
+module github.com/ceramicnetwork/go-dag-jose
 
-go 1.14
+go 1.16
 
 require (
 	github.com/ipfs/go-cid v0.0.7


### PR DESCRIPTION
I also went ahead and made it say "go 1.16", because iirc, there is generally no harm to this, and also mod files start behaving rather better in and after that function.