### PR TITLE
Introduce tests using fixtures from the ipld/ipld repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ipld"]
+	path = .ipld
+	url = https://github.com/ipld/ipld/

--- a/dagjose/spec_test.go
+++ b/dagjose/spec_test.go
@@ -39,7 +39,7 @@ func TestSpecFixtures(t *testing.T) {
 		t.Run(dir.Name, func(t *testing.T) {
 			// We always expect the hunk with dag-jose in hex form.
 			// Parse the hex (and strip linebreaks, which should be about every 80 chars, though that's not enforced).
-			fixtureDataHex := dir.Children["data.dag-jose.hex"].Hunk.Body
+			fixtureDataHex := dir.Children["serial.dag-jose.hex"].Hunk.Body
 			fixtureDataHex = bytes.ReplaceAll(fixtureDataHex, []byte{'\n'}, []byte{})
 			fixtureDataBinary := make([]byte, hex.DecodedLen(len(fixtureDataHex)))
 			i, err := hex.Decode(fixtureDataBinary, fixtureDataHex)
@@ -83,7 +83,7 @@ func TestSpecFixtures(t *testing.T) {
 					})
 				}
 
-				if fixtureJson, exists := dir.Children["data.dag-json-pretty"]; exists {
+				if fixtureJson, exists := dir.Children["datamodel.dag-json.pretty"]; exists {
 					t.Run("datamodel-dagjson", func(t *testing.T) {
 						dagjson, err := ipld.Encode(n, dagjson.Encode)
 						if err != nil {

--- a/dagjose/spec_test.go
+++ b/dagjose/spec_test.go
@@ -1,0 +1,105 @@
+package dagjose
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/traversal"
+	"github.com/warpfork/go-testmark"
+)
+
+func TestSpecFixtures(t *testing.T) {
+	// Load the file.
+	// Also prepare a patch accumlater in case we're in regen mode.
+	file := "../.ipld/specs/codecs/dag-jose/fixtures/index.md"
+	doc, err := testmark.ReadFile(file)
+	if os.IsNotExist(err) {
+		t.Skipf("not running spec suite: %s (did you clone the submodule with the data?)", err)
+	}
+	if err != nil {
+		t.Fatalf("spec file parse failed?!: %s", err)
+	}
+	var patches testmark.PatchAccumulator
+	defer func() {
+		if *testmark.Regen {
+			patches.WriteFileWithPatches(doc, file)
+		}
+	}()
+
+	// Data hunk in this spec file are in "directories" of a test scenario each.
+	doc.BuildDirIndex()
+	for _, dir := range doc.DirEnt.ChildrenList {
+		t.Run(dir.Name, func(t *testing.T) {
+			// We always expect the hunk with dag-jose in hex form.
+			// Parse the hex (and strip linebreaks, which should be about every 80 chars, though that's not enforced).
+			fixtureDataHex := dir.Children["data.dag-jose.hex"].Hunk.Body
+			fixtureDataHex = bytes.ReplaceAll(fixtureDataHex, []byte{'\n'}, []byte{})
+			fixtureDataBinary := make([]byte, hex.DecodedLen(len(fixtureDataHex)))
+			i, err := hex.Decode(fixtureDataBinary, fixtureDataHex)
+			if err != nil {
+				t.Fatalf("invalid fixture: %s at position %v", err, i)
+			}
+
+			t.Run("decode", func(t *testing.T) {
+				n, err := ipld.Decode(fixtureDataBinary, Decode)
+				if err != nil {
+					t.Fatalf("%s", err)
+				}
+
+				t.Run("reencode", func(t *testing.T) {
+					reencodeBinary, err := ipld.Encode(n, Encode)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					// Encode back to hex string.  We'll diff on this as the test because if it's not equal, that produces the most readable feedback.
+					reencodeHex := hex.EncodeToString(reencodeBinary)
+					qt.Check(t, reencodeHex, qt.Equals, string(fixtureDataHex))
+				})
+
+				if fixturePaths, exists := dir.Children["paths"]; exists {
+					t.Run("datamodel-pathlist", func(t *testing.T) {
+						var foundPaths bytes.Buffer
+						traversal.Walk(n, func(tp traversal.Progress, _ datamodel.Node) error {
+							if tp.Path.Len() == 0 {
+								return nil
+							}
+							foundPaths.WriteString(tp.Path.String())
+							foundPaths.WriteRune('\n')
+							return nil
+						})
+
+						if *testmark.Regen {
+							patches.AppendPatchIfBodyDiffers(*fixturePaths.Hunk, foundPaths.Bytes())
+						} else {
+							qt.Check(t, foundPaths.String(), qt.Equals, string(fixturePaths.Hunk.Body))
+						}
+					})
+				}
+
+				if fixtureJson, exists := dir.Children["data.dag-json-pretty"]; exists {
+					t.Run("datamodel-dagjson", func(t *testing.T) {
+						dagjson, err := ipld.Encode(n, dagjson.Encode)
+						if err != nil {
+							t.Fatalf("%s", err)
+						}
+						var dagjsonPretty bytes.Buffer
+						json.Indent(&dagjsonPretty, dagjson, "", "\t")
+
+						if *testmark.Regen {
+							patches.AppendPatchIfBodyDiffers(*fixtureJson.Hunk, dagjsonPretty.Bytes())
+						} else {
+							qt.Check(t, dagjsonPretty.String()+"\n", qt.Equals, string(fixtureJson.Hunk.Body))
+						}
+					})
+				}
+			})
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/ceramicnetwork/go-dag-jose
 go 1.16
 
 require (
+	github.com/frankban/quicktest v1.14.0
 	github.com/ipfs/go-cid v0.0.7
-	github.com/ipld/go-ipld-prime v0.14.0
+	github.com/ipld/go-ipld-prime v0.14.1-0.20211119015904-892d2f92ba8b
 	github.com/multiformats/go-multibase v0.0.3
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/stretchr/testify v1.6.1
+	github.com/warpfork/go-testmark v0.9.0
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	gopkg.in/square/go-jose.v2 v2.5.1
 	pgregory.net/rapid v0.4.7

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/ipfs/go-cid v0.0.4/go.mod h1:4LLaPOQwmk5z9LBgQnpkivrx8BJjUyGwTXCd5Xfj6+M=
 github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
-github.com/ipld/go-ipld-prime v0.14.0 h1:2FnBqUjmmgxgZD6/zB3eygWlmIsHNGrZ57L99x3xD6Q=
-github.com/ipld/go-ipld-prime v0.14.0/go.mod h1:9ASQLwUFLptCov6lIYc70GRB4V7UTyLD0IJtrDJe6ZM=
+github.com/ipld/go-ipld-prime v0.14.1-0.20211119015904-892d2f92ba8b h1:zkY0G0B/AWP3wg00bdMyfGRptDd7XJHDoOndJiM+rwk=
+github.com/ipld/go-ipld-prime v0.14.1-0.20211119015904-892d2f92ba8b/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704nH0RDcQtgTP0=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -66,6 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/warpfork/go-testmark v0.3.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
+github.com/warpfork/go-testmark v0.9.0 h1:nc+uaCiv5lFQLYjhuC2LTYeJ7JaC+gdDmsz9r0ISy0Y=
+github.com/warpfork/go-testmark v0.9.0/go.mod h1:jhEf8FVxd+F17juRubpmut64NEG6I2rgkUhlcqqXwE0=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
## Description

I've added fixtures for dag-jose to the ipld/ipld repo.  This diff adds code to run them; and a git submodule which drags in the ipld/ipld repo (so we've got something to run).

The fixtures themselves are materially the same as some other fixtures already used in another repo, but I've put them in a new format, and added some more kinds of related fixtures which I hope will increase legibility significantly.

The code both runs the test fixtures, and is also capable of regenerating them (or at least, some of them -- not the initial dag-jose itself (where would it come from?)).  To do the later, simply run `go test ./dagjose/ -testmark.regen`.  (This is quite literally how I produced the rest of the data in https://github.com/ipld/ipld/pull/151 .)

(A git submodule?  Yes.  I think this is the [least bad](https://github.com/ipld/go-ipld-prime/pull/218#issuecomment-892523424) way to solve this linkage.  Counterproposals welcome, though.  I know many people don't consider them a joy to maintain.)

## How Has This Been Tested?

The entire PR is tests :)

For the data: seealso https://github.com/ipld/ipld/pull/151 .  (That review is probably more critical than this one!)

## Definition of Done

Before submitting this PR, please make sure:

- [x] The work addresses the description and outcomes in the issue
- [x] I have added relevant tests for new or updated functionality
- [x] My code follows conventions, is well commented, and easy to understand
- [x] My code builds and tests pass without any errors or warnings
- [x] I have tagged the relevant reviewers
- [x] I have updated the READMEs of affected packages
- [x] I have made corresponding changes to the documentation
- [x] The changes have been communicated to interested parties

